### PR TITLE
Bump julia version

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+style = "yas"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,10 +1,18 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.7.0"
+julia_version = "1.10.1"
 manifest_format = "2.0"
+project_hash = "1907bfa46a4a9d8677f7cb8f159f242fb390271d"
+
+[[deps.AliasTables]]
+deps = ["Random"]
+git-tree-sha1 = "ca95b2220ef440817963baa71525a8f2f4ae7f8f"
+uuid = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
+version = "1.0.0"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -18,64 +26,62 @@ git-tree-sha1 = "f641eb0a4f00c343bbc32346e1217b86f3ce9dad"
 uuid = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
 version = "0.5.1"
 
-[[deps.ChainRulesCore]]
-deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "80ca332f6dcb2508adba68f22f551adb2d00a624"
-uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.15.3"
-
-[[deps.ChangesOfVariables]]
-deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
-git-tree-sha1 = "38f7a08f19d8810338d4f5085211c7dfa5d5bdd8"
-uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
-version = "0.1.4"
-
 [[deps.Compat]]
-deps = ["Dates", "LinearAlgebra", "UUIDs"]
-git-tree-sha1 = "924cdca592bc16f14d2f7006754a621735280b74"
+deps = ["TOML", "UUIDs"]
+git-tree-sha1 = "c955881e3c981181362ae4088b35995446298b80"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.1.0"
+version = "4.14.0"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.1.0+0"
 
 [[deps.DataAPI]]
-git-tree-sha1 = "fb5f5316dd3fd4c5e7c30a24d50643b73e37cd40"
+git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.10.0"
+version = "1.16.0"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "d1fff3a548102f48987a52a2e0d114fa97d730f0"
+git-tree-sha1 = "1d0a14036acb104d9e89698bd408f63ab58cdc82"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.13"
+version = "0.18.20"
 
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
-[[deps.DensityInterface]]
-deps = ["InverseFunctions", "Test"]
-git-tree-sha1 = "80c3e8639e3353e5d2912fb3a1916b8455e2494b"
-uuid = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
-version = "0.4.0"
-
 [[deps.Distributions]]
-deps = ["ChainRulesCore", "DensityInterface", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns", "Test"]
-git-tree-sha1 = "aafa0665e3db0d3d0890cdc8191ea03dc279b042"
+deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
+git-tree-sha1 = "22c595ca4146c07b16bcf9c8bea86f731f7109d2"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.66"
+version = "0.25.108"
+
+    [deps.Distributions.extensions]
+    DistributionsChainRulesCoreExt = "ChainRulesCore"
+    DistributionsDensityInterfaceExt = "DensityInterface"
+    DistributionsTestExt = "Test"
+
+    [deps.Distributions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    DensityInterface = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[deps.DocStringExtensions]]
 deps = ["LibGit2"]
-git-tree-sha1 = "5158c2b41018c5f7eb1470d558127ac274eca0c9"
+git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.9.1"
+version = "0.9.3"
 
 [[deps.Downloads]]
-deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
 
 [[deps.DualNumbers]]
 deps = ["Calculus", "NaNMath", "SpecialFunctions"]
@@ -83,67 +89,88 @@ git-tree-sha1 = "5837a837389fccf076445fce071c8ddaea35a566"
 uuid = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
 version = "0.6.8"
 
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
 [[deps.FillArrays]]
-deps = ["LinearAlgebra", "Random", "SparseArrays", "Statistics"]
-git-tree-sha1 = "246621d23d1f43e3b9c368bf3b72b2331a27c286"
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "bfe82a708416cf00b73a3198db0859c82f741558"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.13.2"
+version = "1.10.0"
+weakdeps = ["PDMats", "SparseArrays", "Statistics"]
+
+    [deps.FillArrays.extensions]
+    FillArraysPDMatsExt = "PDMats"
+    FillArraysSparseArraysExt = "SparseArrays"
+    FillArraysStatisticsExt = "Statistics"
 
 [[deps.HypergeometricFunctions]]
-deps = ["DualNumbers", "LinearAlgebra", "OpenLibm_jll", "SpecialFunctions", "Test"]
-git-tree-sha1 = "709d864e3ed6e3545230601f94e11ebc65994641"
+deps = ["DualNumbers", "LinearAlgebra", "OpenLibm_jll", "SpecialFunctions"]
+git-tree-sha1 = "f218fe3736ddf977e0e772bc9a586b2383da2685"
 uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
-version = "0.3.11"
+version = "0.3.23"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
-[[deps.InverseFunctions]]
-deps = ["Test"]
-git-tree-sha1 = "b3364212fb5d870f724876ffcd34dd8ec6d98918"
-uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
-version = "0.1.7"
-
 [[deps.IrrationalConstants]]
-git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+git-tree-sha1 = "630b497eafcc20001bba38a4651b327dcfc491d2"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
-version = "0.1.1"
+version = "0.2.2"
 
 [[deps.JLLWrappers]]
-deps = ["Preferences"]
-git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.4.1"
+version = "1.5.0"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
 
 [[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.4.0+0"
 
 [[deps.LibGit2]]
-deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.6.4+0"
 
 [[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.0+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[deps.LinearAlgebra]]
-deps = ["Libdl", "libblastrampoline_jll"]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.LogExpFunctions]]
-deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "361c2b088575b07946508f135ac556751240091c"
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "18144f3e9cbe9b15b070288eef858f71b291ce37"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.17"
+version = "0.3.27"
+
+    [deps.LogExpFunctions.extensions]
+    LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+    LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+    LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.LogExpFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -155,32 +182,37 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.2+1"
 
 [[deps.Missings]]
 deps = ["DataAPI"]
-git-tree-sha1 = "bf210ce90b6c9eed32d25dbcae1ebc565df2687f"
+git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "1.0.2"
+version = "1.2.0"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2023.1.10"
 
 [[deps.NaNMath]]
 deps = ["OpenLibm_jll"]
-git-tree-sha1 = "a7c3d1da1189a1c2fe843a3bfa04d18d20eb3211"
+git-tree-sha1 = "0877504529a3e5c3343c6f8b4c0381e57e4387e4"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-version = "1.0.1"
+version = "1.0.2"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
 
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.23+4"
 
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.8.1+2"
 
 [[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -189,25 +221,26 @@ uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 version = "0.5.5+0"
 
 [[deps.OrderedCollections]]
-git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.4.1"
+version = "1.6.3"
 
 [[deps.PDMats]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "cf494dca75a69712a72b80bc48f59dcf3dea63ec"
+git-tree-sha1 = "949347156c25054de2db3b166c52ac4728cbad65"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.16"
+version = "0.11.31"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.10.0"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "47e5f437cc0e7ef2ce8406ce1e7e24d44915f88d"
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.3.0"
+version = "1.4.3"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -215,16 +248,16 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[deps.QuadGK]]
 deps = ["DataStructures", "LinearAlgebra"]
-git-tree-sha1 = "78aadffb3efd2155af139781b8a8df1ef279ea39"
+git-tree-sha1 = "9b23c31e76e333e6fb4c1595ae6afa74966a729e"
 uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
-version = "2.4.2"
+version = "2.9.4"
 
 [[deps.REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.Random]]
-deps = ["SHA", "Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.Reexport]]
@@ -234,18 +267,19 @@ version = "1.2.2"
 
 [[deps.Rmath]]
 deps = ["Random", "Rmath_jll"]
-git-tree-sha1 = "bf3188feca147ce108c76ad82c2792c57abe7b1f"
+git-tree-sha1 = "f65dcb5fa46aee0cf9ed6274ccbd597adc49aa7b"
 uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
-version = "0.7.0"
+version = "0.7.1"
 
 [[deps.Rmath_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "68db32dff12bb6127bac73c209881191bf0efbb7"
+git-tree-sha1 = "6ed52fdd3382cf21947b15e8870ac0ddbff736da"
 uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
-version = "0.3.0+0"
+version = "0.4.0+0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -255,53 +289,76 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [[deps.SortingAlgorithms]]
 deps = ["DataStructures"]
-git-tree-sha1 = "b3363d7460f7d098ca0912c69b082f75625d7508"
+git-tree-sha1 = "66e0a8e672a0bdfca2c3f5937efb8538b9ddc085"
 uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
-version = "1.0.1"
+version = "1.2.1"
 
 [[deps.SparseArrays]]
-deps = ["LinearAlgebra", "Random"]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.10.0"
 
 [[deps.SpecialFunctions]]
-deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "d75bda01f8c31ebb72df80a46c88b25d1c79c56d"
+deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "e2cfc4012a19088254b3950b85c3c1d8882d864d"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.1.7"
+version = "2.3.1"
+
+    [deps.SpecialFunctions.extensions]
+    SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
+
+    [deps.SpecialFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 
 [[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.10.0"
 
 [[deps.StatsAPI]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "f9af7f195fb13589dd2e2d57fdb401717d2eb1f6"
+git-tree-sha1 = "1ff449ad350c9c4cbc756624d6f8a8c3ef56d3ed"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
-version = "1.5.0"
+version = "1.7.0"
 
 [[deps.StatsBase]]
 deps = ["DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
-git-tree-sha1 = "d1bf48bfcc554a3761a133fe3a9bb01488e06916"
+git-tree-sha1 = "5cf7606d6cef84b543b483848d4ae08ad9832b21"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.33.21"
+version = "0.34.3"
 
 [[deps.StatsFuns]]
-deps = ["ChainRulesCore", "HypergeometricFunctions", "InverseFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
-git-tree-sha1 = "5783b877201a82fc0014cbf381e7e6eb130473a4"
+deps = ["HypergeometricFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
+git-tree-sha1 = "cef0472124fab0695b58ca35a77c6fb942fdab8a"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-version = "1.0.1"
+version = "1.3.1"
+
+    [deps.StatsFuns.extensions]
+    StatsFunsChainRulesCoreExt = "ChainRulesCore"
+    StatsFunsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.StatsFuns.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 
 [[deps.SuiteSparse]]
 deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
 uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.2.1+1"
+
 [[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
 
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
 
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
@@ -317,15 +374,19 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+1"
 
 [[deps.libblastrampoline_jll]]
-deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.8.0+1"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.52.0+1"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+2"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.7
+julia >= 1.7
 Distributions

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,16 +1,10 @@
 using Documenter
 using FinancialDerivatives
 
-makedocs(
-    format = :html,
-    sitename = "FinancialDerivatives.jl",
-    pages = [
-        "index.md",
-        "getting_started.md",
-        "api.md"
-    ]
-)
+makedocs(; format=:html,
+         sitename="FinancialDerivatives.jl",
+         pages=["index.md",
+                "getting_started.md",
+                "api.md"])
 
-deploydocs(
-    repo = "github.com/JuliaQuant/FinancialDerivatives.jl.git"
-)
+deploydocs(; repo="github.com/JuliaQuant/FinancialDerivatives.jl.git")

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -2,10 +2,10 @@
 
 ## Installation
 
-`FinancialDerivatives` is a unregistered package for the moment. To add it to your Julia packages, simply do the following in REPL:
+`FinancialDerivatives` is a registered package. To add it to your Julia packages, simply do the following in REPL:
 
 ```julia
-(v1.0) pkg> add https://github.com/JuliaQuant/FinancialDerivatives.jl
+pkg> add FinancialDerivatives
 ```
 
 ## Usage
@@ -15,7 +15,7 @@ To price an European option, simply create a new `EuropeanOption` and pass it to
 ```julia
 julia> using FinancialDerivatives
 
-julia> euro_put = EuropeanOption(100.0, 90.0, 0.05, 0.3, 180/365, -1)
+julia> euro_put = EuropeanOption(100.0, 90.0, 0.05, 0.3, 180/365, true)
 
 julia> evaluate(euro_put, BlackScholes())
 3.2281936525908073

--- a/src/FinancialDerivatives.jl
+++ b/src/FinancialDerivatives.jl
@@ -10,7 +10,9 @@ export InterestRateDerivative,
        AmericanOption,
        AsianOption,
        EuropeanOption,
-       FXOption
+       FXOption,
+       iscall,
+       isput
 
 export BlackKarasinski,
        BlackScholes,

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -18,6 +18,12 @@ Abstract type for [option](https://en.wikipedia.org/wiki/Option_(finance)).
 """
 abstract type Option <: Derivative end
 
+"Return `true` if the `Option` `o` is a put option"
+isput(o::Option) = !iscall(o)
+
+"Return `true` if the `Option` `o` is a call option"
+iscall(o::Option) = o.call
+
 """
 Abstract type for [swap](https://en.wikipedia.org/wiki/Swap_(finance)).
 """
@@ -40,12 +46,12 @@ abstract type Swaption <: Derivative end
 - `θ`: long term mean level
 - `t`: time interval
 """
-struct InterestRateDerivative
-    k::Real
-    r::Real
-    σ::Real
-    θ::Real
-    t::Real
+struct InterestRateDerivative{KT<:Real,RT<:Real,σT<:Real,θT<:Real,TT<:Real}
+    k::KT
+    r::RT
+    σ::σT
+    θ::θT
+    t::TT
 end
 
 """
@@ -59,15 +65,15 @@ end
 - `r`: risk-free interest rate
 - `σ`: volatility
 - `t`: time to expiration
-- `call`: 1 if call, -1 if put
+- `call`: `true` if call, `false` if put
 """
-struct AmericanOption <: Option
-    s::Real
-    k::Real
-    r::Real
-    σ::Real
-    t::Real
-    call::Int64
+struct AmericanOption{ST<:Real,KT<:Real,RT<:Real,σT<:Real,TT<:Real} <: Option
+    s::ST
+    k::KT
+    r::RT
+    σ::σT
+    t::TT
+    call::Bool
 end
 
 """
@@ -81,15 +87,15 @@ end
 - `r`: risk-free interest rate
 - `σ`: volatility
 - `t`: time to expiration
-- `call`: 1 if call, -1 if put
+- `call`: `true` if call, `false` if put
 """
-struct AsianOption <: Option
-    s::Real
-    k::Real
-    r::Real
-    σ::Real
-    t::Real
-    call::Int64
+struct AsianOption{ST<:Real,KT<:Real,RT<:Real,σT<:Real,TT<:Real} <: Option
+    s::ST
+    k::KT
+    r::RT
+    σ::σT
+    t::TT
+    call::Bool
 end
 
 """
@@ -103,15 +109,15 @@ end
 - `r`: risk-free interest rate
 - `σ`: volatility
 - `t`: time to expiration
-- `call`: 1 if call, -1 if put
+- `call`: `true` if call, `false` if put
 """
-struct EuropeanOption <: Option
-    s::Real
-    k::Real
-    r::Real
-    σ::Real
-    t::Real
-    call::Int64
+struct EuropeanOption{ST<:Real,KT<:Real,RT<:Real,σT<:Real,TT<:Real} <: Option
+    s::ST
+    k::KT
+    r::RT
+    σ::σT
+    t::TT
+    call::Bool
 end
 
 """
@@ -126,14 +132,14 @@ end
 - `r_f`: foreign risk-free interest rate
 - `σ`: volatility
 - `t`: time to expiration
-- `call`: 1 if call, -1 if put
+- `call`: `true` if call, `false` if put
 """
-struct FXOption <: Option
-    s::Real
-    k::Real
-    r_d::Real
-    r_f::Real
-    σ::Real
-    t::Real
-    call::Int64
+struct FXOption{ST<:Real,KT<:Real,RDT<:Real,RFT<:Real,σT<:Real,TT<:Real} <: Option
+    s::ST
+    k::KT
+    r_d::RDT
+    r_f::RFT
+    σ::σT
+    t::TT
+    call::Bool
 end

--- a/src/models/black_karasinski.jl
+++ b/src/models/black_karasinski.jl
@@ -14,10 +14,10 @@ Evaluate interest rate derivative using `BlackKarasinski` model.
 - `IRD::InterestRateDerivative`: interest rate derivative
 - `n`: number of paths to simulate
 """
-function evaluate(IRD::InterestRateDerivative, m::BlackKarasinski, n::Int64 = 12)
+function evaluate(IRD::InterestRateDerivative, m::BlackKarasinski, n::Int64=12)
     Δt = IRD.t / n
     rates = [IRD.r]
-    for i = 0:n
+    for i in 0:n
         dr = IRD.k * (IRD.θ - log(rates[end])) * Δt + IRD.σ * rates[end] * randn()
         append!(rates, rates[end] + dr)
     end

--- a/src/models/black_scholes.jl
+++ b/src/models/black_scholes.jl
@@ -17,13 +17,12 @@ function evaluate(O::EuropeanOption, m::BlackScholes)
     d1 = (log(O.s / O.k) + (O.r + O.σ * O.σ / 2) * O.t) / (O.σ * √O.t)
     d2 = d1 - O.σ * √O.t
 
-    if O.call == -1
+    if isput(O)
         return cdf(Normal(), -d2) * O.k * exp(-O.r * O.t) - cdf(Normal(), -d1) * O.s
-    elseif O.call == 1
+    elseif iscall(O)
         return O.s * cdf(Normal(), d1) - exp(-O.r * O.t) * O.k * cdf(Normal(), d2)
     end
 end
-
 
 """
     evaluate(o)

--- a/src/models/brennan_schwartz.jl
+++ b/src/models/brennan_schwartz.jl
@@ -14,10 +14,10 @@ Evaluate interest rate derivative `IRD` using `BrennanSchwartz` model.
 - `IRD::InterestRateDerivative`: interest rate derivative
 - `n`: number of paths to simulate
 """
-function evaluate(IRD::InterestRateDerivative, m::BrennanSchwartz, n::Int64 = 12)
+function evaluate(IRD::InterestRateDerivative, m::BrennanSchwartz, n::Int64=12)
     Δt = IRD.t / n
     rates = [IRD.r]
-    for i = 0:n
+    for i in 0:n
         dr = IRD.k * (IRD.θ - rates[end]) * Δt + IRD.σ * randn()
         append!(rates, rates[end] + dr)
     end

--- a/src/models/cox_ingersoll_ross.jl
+++ b/src/models/cox_ingersoll_ross.jl
@@ -14,10 +14,10 @@ Evaluate interest rate derivative `IRD` using `CoxIngersollRoss` model.
 - `IRD::InterestRateDerivative`: interest rate derivative
 - `n`: number of paths to simulate
 """
-function evaluate(IRD::InterestRateDerivative, m::CoxIngersollRoss, n::Int64 = 12)
+function evaluate(IRD::InterestRateDerivative, m::CoxIngersollRoss, n::Int64=12)
     Δt = IRD.t / n
     rates = [IRD.r]
-    for i = 0:n
+    for i in 0:n
         dr = IRD.k * (IRD.θ - rates[end]) * Δt + IRD.σ * √rates[end] * randn()
         append!(rates, rates[end] + dr)
     end

--- a/src/models/cox_ross_rubinstein.jl
+++ b/src/models/cox_ross_rubinstein.jl
@@ -14,7 +14,7 @@ Evaluate option `O` using `CoxRossRubinstein`.
 - `O::Option`: option
 - `N`: number of paths to simulate
 """
-function evaluate(O::Option, m::CoxRossRubinstein, N::Int64 = 1000)
+function evaluate(O::Option, m::CoxRossRubinstein, N::Int64=1000)
     Δt = O.t / N
     U = exp(O.σ * √Δt)
     D = exp(-O.σ * √Δt)
@@ -22,21 +22,21 @@ function evaluate(O::Option, m::CoxRossRubinstein, N::Int64 = 1000)
     p = (R - D) / (U - D)
     q = (U - R) / (U - D)
 
-    if O.call == -1
-        Z = [max(0, O.k - O.s * exp((2 * i - N) * O.σ * √Δt)) for i = 0:N]
-    elseif O.call == 1
-        Z = [max(0, O.s * exp((2 * i - N) * O.σ * √Δt) - O.k) for i = 0:N]
+    if isput(O)
+        Z = [max(0, O.k - O.s * exp((2 * i - N) * O.σ * √Δt)) for i in 0:N]
+    elseif iscall(O)
+        Z = [max(0, O.s * exp((2 * i - N) * O.σ * √Δt) - O.k) for i in 0:N]
     end
-    
-    for n = N-1:-1:0, i = 0:n
-        if O.call == -1
+
+    for n in (N - 1):-1:0, i in 0:n
+        if isput(O)
             x = O.k - O.s * exp((2 * i - n) * O.σ * √Δt)
-        elseif O.call == 1
+        elseif iscall(O)
             x = O.s * exp((2 * i - n) * O.σ * √Δt) - O.k
         end
-        y = (q * Z[i+1] + p * Z[i+2]) / R
-        Z[i+1] = max(x, y)
+        y = (q * Z[i + 1] + p * Z[i + 2]) / R
+        Z[i + 1] = max(x, y)
     end
-    
+
     return Z[1]
 end

--- a/src/models/garman_kohlhagen.jl
+++ b/src/models/garman_kohlhagen.jl
@@ -17,9 +17,11 @@ function evaluate(O::FXOption, m::GarmanKohlhagen)
     d1 = (log(O.s / O.k) + (O.r_d - O.r_f * O.σ / 2) * O.t) / (O.σ * √O.t)
     d2 = d1 - O.σ * √O.t
 
-    if O.call == -1
-        return O.k * exp(-O.r_d * O.t) * cdf(Normal(), -d2) - O.s * exp(-O.r_f * O.t) * cdf(Normal(), -d1)
-    elseif O.call == 1
-        return O.s * exp(-O.r_f * O.t) * cdf(Normal(), d1) - O.k * exp(-O.r_d * O.t) * cdf(Normal(), d2)
+    if isput(O)
+        return O.k * exp(-O.r_d * O.t) * cdf(Normal(), -d2) -
+               O.s * exp(-O.r_f * O.t) * cdf(Normal(), -d1)
+    elseif iscall(O)
+        return O.s * exp(-O.r_f * O.t) * cdf(Normal(), d1) -
+               O.k * exp(-O.r_d * O.t) * cdf(Normal(), d2)
     end
 end

--- a/src/models/jarrow_rudd.jl
+++ b/src/models/jarrow_rudd.jl
@@ -10,39 +10,39 @@ struct JarrowRudd <: Model end
 
 Evaluate option `O` using `JarrowRudd` binomial model (defaults to the risk-neutral version).
 
-# Arguments
+# Arguments 
 - `O::Option`: option
 - `risk_neutral`: `true` if risk neutral, `false` if equal probability.
 - `N`: number of paths to simulate
 """
-function evaluate(O::Option, m::JarrowRudd, risk_neutral::Bool = true, N::Int64 = 1000)
+function evaluate(O::Option, m::JarrowRudd, risk_neutral::Bool=true, N::Int64=1000)
     Δt = O.t / N
     R = exp(O.r * Δt)
 
     if risk_neutral
-         U = exp((O.r - O.σ^2 / 2) * Δt + O.σ * √Δt)
-         D = exp((O.r - O.σ^2 / 2) * Δt - O.σ * √Δt)
-         p = (R - D) / (U - D)
-         q = (U - R) / (U - D)
+        U = exp((O.r - O.σ^2 / 2) * Δt + O.σ * √Δt)
+        D = exp((O.r - O.σ^2 / 2) * Δt - O.σ * √Δt)
+        p = (R - D) / (U - D)
+        q = (U - R) / (U - D)
     else
         p = q = 0.5
     end
-    
-    if O.call == -1
-        Z = [max(0, O.k - O.s * exp((2 * i - N) * O.σ * √Δt)) for i = 0:N]
-    elseif O.call == 1
-        Z = [max(0, O.s * exp((2 * i - N) * O.σ * √Δt) - O.k) for i = 0:N]
+
+    if isput(O)
+        Z = [max(0, O.k - O.s * exp((2 * i - N) * O.σ * √Δt)) for i in 0:N]
+    elseif iscall(O)
+        Z = [max(0, O.s * exp((2 * i - N) * O.σ * √Δt) - O.k) for i in 0:N]
     end
-    
-    for n = N-1:-1:0, i = 0:n
-        if O.call == -1
+
+    for n in (N - 1):-1:0, i in 0:n
+        if isput(O)
             x = O.k - O.s * exp((2 * i - n) * O.σ * √Δt)
-        elseif O.call == 1
+        elseif iscall(O)
             x = O.s * exp((2 * i - n) * O.σ * √Δt) - O.k
         end
-        y = (q * Z[i+1] + p * Z[i+2]) / exp(O.r * Δt)
-        Z[i+1] = max(x, y)
+        y = (q * Z[i + 1] + p * Z[i + 2]) / exp(O.r * Δt)
+        Z[i + 1] = max(x, y)
     end
-    
+
     return Z[1]
 end

--- a/src/models/leisen_reimer.jl
+++ b/src/models/leisen_reimer.jl
@@ -6,7 +6,8 @@
 struct LeisenReimer <: Model end
 
 function h(z::T, n::Int64) where {T<:Number}
-    return 0.5 + sign(z) * 0.5 * sqrt(1 - exp(-((z / (n + 1.0 / 3.0))^2.0) * (n + 1.0 / 6.0)))
+    return 0.5 +
+           sign(z) * 0.5 * sqrt(1 - exp(-((z / (n + 1.0 / 3.0))^2.0) * (n + 1.0 / 6.0)))
 end
 
 """
@@ -17,7 +18,7 @@ Evaluate option `O` using `LeisenReimer` binomial model.
 # Arguments
 - `N`: number of paths to simulate, must be odd
 """
-function evaluate(O::Option, m::LeisenReimer, N::Int64 = 1001)
+function evaluate(O::Option, m::LeisenReimer, N::Int64=1001)
     Δt = 0.01 # O.t / N
     R = exp(O.r * Δt)
     d1 = (log(O.s / O.k) + (O.r + O.σ * O.σ / 2) * O.t) / (O.σ * √O.t)
@@ -25,21 +26,21 @@ function evaluate(O::Option, m::LeisenReimer, N::Int64 = 1001)
     p = h(d2, N)
     q = 1 - p
 
-    if O.call == -1
-        Z = [max(0, O.k - O.s * exp((2 * i - N) * O.σ * √Δt)) for i = 0:N]
-    elseif O.call == 1
-        Z = [max(0, O.s * exp((2 * i - N) * O.σ * √Δt) - O.k) for i = 0:N]
+    if isput(O)
+        Z = [max(0, O.k - O.s * exp((2 * i - N) * O.σ * √Δt)) for i in 0:N]
+    elseif iscall(O)
+        Z = [max(0, O.s * exp((2 * i - N) * O.σ * √Δt) - O.k) for i in 0:N]
     end
-    
-    for n = N-1:-1:0, i = 0:n
-        if O.call == -1
+
+    for n in (N - 1):-1:0, i in 0:n
+        if isput(O)
             x = O.k - O.s * exp((2 * i - n) * O.σ * √Δt)
-        elseif O.call == 1
+        elseif iscall(O)
             x = O.s * exp((2 * i - n) * O.σ * √Δt) - O.k
         end
-        y = (q * Z[i+1] + p * Z[i+2]) / exp(O.r * Δt)
-        Z[i+1] = max(x, y)
+        y = (q * Z[i + 1] + p * Z[i + 2]) / exp(O.r * Δt)
+        Z[i + 1] = max(x, y)
     end
-    
+
     return Z[1]
 end

--- a/src/models/longstaff_schwartz.jl
+++ b/src/models/longstaff_schwartz.jl
@@ -14,33 +14,33 @@ Evaluate option `O` using `LongstaffSchwartz` binomial model.
 - `N`: number of paths to simulate
 - `P`: number of periods
 """
-function evaluate(O::AmericanOption, m::LongstaffSchwartz, N::Int64 = 1000, P::Int64 = 10000)
+function evaluate(O::AmericanOption, m::LongstaffSchwartz, N::Int64=1000, P::Int64=10000)
     Δt = O.t / N
     R = exp(O.r * Δt)
     T = typeof(O.s * exp(-O.σ^2 * Δt / 2 + O.σ * √Δt * 0.1) / R)
-    X = Array{T}(undef, N+1, P)
+    X = Array{T}(undef, N + 1, P)
 
-    for p = 1:P
+    for p in 1:P
         X[1, p] = x = O.s
-        for n = 1:N
+        for n in 1:N
             x *= R * exp(-O.σ^2 * Δt / 2 + O.σ * √Δt * randn())
-            X[n+1, p] = x
+            X[n + 1, p] = x
         end
     end
 
-    if O.call == -1
-        V = [max(O.k - x, 0) / R for x in X[N+1, :]]
-    elseif O.call == 1
-        V = [max(x - O.k, 0) / R for x in X[N+1, :]]
+    if isput(O)
+        V = [max(O.k - x, 0) / R for x in X[N + 1, :]]
+    elseif iscall(O)
+        V = [max(x - O.k, 0) / R for x in X[N + 1, :]]
     end
 
-    for n = N-1:-1:1
+    for n in (N - 1):-1:1
         I = V .!= 0
-        A = [x^d for d = 0:3, x in X[n+1, :]]
+        A = [x^d for d in 0:3, x in X[n + 1, :]]
         β = A[:, I]' \ V[I]
         cV = A' * β
-        for p = 1:P
-            ev = max(O.k - X[n+1, p], 0)
+        for p in 1:P
+            ev = max(O.k - X[n + 1, p], 0)
             if I[p] && cV[p] < ev
                 V[p] = ev / R
             else
@@ -49,9 +49,9 @@ function evaluate(O::AmericanOption, m::LongstaffSchwartz, N::Int64 = 1000, P::I
         end
     end
 
-    if O.call == -1
+    if isput(O)
         return max(mean(V), O.k - O.s)
-    elseif O.call == 1
+    elseif iscall(O)
         return max(mean(V), O.s - O.k)
     end
 end

--- a/src/models/rendleman_bartter.jl
+++ b/src/models/rendleman_bartter.jl
@@ -13,10 +13,10 @@ Evaluate interest rate derivative `IRD` using `RendlemanBartter` model.
 # Arguments
 - `n`: number of paths to simulate
 """
-function evaluate(IRD::InterestRateDerivative, m::RendlemanBartter, n::Int64 = 12)
+function evaluate(IRD::InterestRateDerivative, m::RendlemanBartter, n::Int64=12)
     Δt = IRD.t / n
     rates = [IRD.r]
-    for i = 0:n
+    for i in 0:n
         dr = IRD.θ * rates[end] * Δt + IRD.θ * rates[end] * randn()
         append!(rates, rates[end] + dr)
     end
@@ -32,26 +32,26 @@ Evaluate option `O` using `RendlemanBartter` model.
 - `k`:
 - `N`: 
 """
-function evaluate(O::Option, m::RendlemanBartter, k::Int64 = 1, N::Int64 = 1000)
+function evaluate(O::Option, m::RendlemanBartter, k::Int64=1, N::Int64=1000)
     Δt = O.t / N
     p = 1 / (1 + k^2)
     q = 1 - p
 
-    if O.call == -1
-        Z = [max(0, O.k - O.s * exp((2 * i - N) * O.σ * √Δt)) for i = 0:N]
-    elseif O.call == 1
-        Z = [max(0, O.s * exp((2 * i - N) * O.σ * √Δt) - O.k) for i = 0:N]
+    if isput(O)
+        Z = [max(0, O.k - O.s * exp((2 * i - N) * O.σ * √Δt)) for i in 0:N]
+    elseif iscall(O)
+        Z = [max(0, O.s * exp((2 * i - N) * O.σ * √Δt) - O.k) for i in 0:N]
     end
-    
-    for n = N-1:-1:0, i = 0:n
-        if O.call == -1
+
+    for n in (N - 1):-1:0, i in 0:n
+        if isput(O)
             x = O.k - O.s * exp((2 * i - n) * O.σ * √Δt)
-        elseif O.call == 1
+        elseif iscall(O)
             x = O.s * exp((2 * i - n) * O.σ * √Δt) - O.k
         end
-        y = (q * Z[i+1] + p * Z[i+2]) / exp(O.r * Δt)
-        Z[i+1] = max(x, y)
+        y = (q * Z[i + 1] + p * Z[i + 2]) / exp(O.r * Δt)
+        Z[i + 1] = max(x, y)
     end
-    
+
     return Z[1]
 end

--- a/src/models/tian.jl
+++ b/src/models/tian.jl
@@ -13,7 +13,7 @@ Evaluate option `O` using `Tian` binomial model.
 # Arguments
 `N`: number of paths to simulate
 """
-function evaluate(O::Option, m::Tian, N::Int64 = 1000)
+function evaluate(O::Option, m::Tian, N::Int64=1000)
     Δt = O.t / N
     R = exp(O.r * Δt)
     v = exp(O.σ^2 * Δt)
@@ -22,21 +22,21 @@ function evaluate(O::Option, m::Tian, N::Int64 = 1000)
     p = (R - D) / (U - D)
     q = (U - R) / (U - D)
 
-    if O.call == -1
-        Z = [max(0, O.k - O.s * exp((2 * i - N) * O.σ * √Δt)) for i = 0:N]
-    elseif O.call == 1
-        Z = [max(0, O.s * exp((2 * i - N) * O.σ * √Δt) - O.k) for i = 0:N]
+    Z = if isput(O)
+        [max(0, O.k - O.s * exp((2 * i - N) * O.σ * √Δt)) for i in 0:N]
+    elseif iscall(O)
+        [max(0, O.s * exp((2 * i - N) * O.σ * √Δt) - O.k) for i in 0:N]
     end
-    
-    for n = N-1:-1:0, i = 0:n
-        if O.call == -1
+
+    for n in (N - 1):-1:0, i in 0:n
+        if isput(O)
             x = O.k - O.s * exp((2 * i - n) * O.σ * √Δt)
-        elseif O.call == 1
+        elseif iscall(O)
             x = O.s * exp((2 * i - n) * O.σ * √Δt) - O.k
         end
-        y = (q * Z[i+1] + p * Z[i+2]) / R
-        Z[i+1] = max(x, y)
+        y = (q * Z[i + 1] + p * Z[i + 2]) / R
+        Z[i + 1] = max(x, y)
     end
-    
+
     return Z[1]
 end

--- a/src/models/vasicek.jl
+++ b/src/models/vasicek.jl
@@ -14,10 +14,10 @@ Evaluate interest rate derivative `IRD` using `Vasicek` model.
 - `n`: number of paths to simulate
 
 """
-function evaluate(IRD::InterestRateDerivative, m::Vasicek, n::Int64 = 12)
+function evaluate(IRD::InterestRateDerivative, m::Vasicek, n::Int64=12)
     Δt = IRD.t / n
     rates = [IRD.r]
-    for i = 0:n
+    for i in 0:n
         dr = IRD.k * (IRD.θ - rates[end]) * Δt + IRD.σ * rates[end] * randn()
         append!(rates, rates[end] + dr)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,11 @@
 using FinancialDerivatives
 using Test
 
-eu_put = EuropeanOption(100.0, 90.0, 0.05, 0.3, 180/365, -1)
-eu_call = EuropeanOption(100.0, 90.0, 0.05, 0.3, 180/365, 1)
+eu_put = EuropeanOption(100.0, 90.0, 0.05, 0.3, 180 / 365, false)
+eu_call = EuropeanOption(100.0, 90.0, 0.05, 0.3, 180 / 365, true)
 
-am_put = AmericanOption(100.0, 90.0, 0.05, 0.3, 180/365, -1)
-am_call = AmericanOption(100.0, 90.0, 0.05, 0.3, 180/365, 1)
+am_put = AmericanOption(100.0, 90.0, 0.05, 0.3, 180 / 365, false)
+am_call = AmericanOption(100.0, 90.0, 0.05, 0.3, 180 / 365, true)
 
 @testset "Black-Scholes" begin
     @test isapprox(evaluate(eu_put, BlackScholes()), 3.22, atol=0.1)
@@ -35,13 +35,13 @@ end
 end
 
 @testset "Garman–Kohlhagen" begin
-    fxp = FXOption(100.0, 90.0, 0.05, 0.025, 0.3, 180/365, -1)
-    fxc = FXOption(100.0, 90.0, 0.05, 0.025, 0.3, 180/365, 1)
+    fxp = FXOption(100.0, 90.0, 0.05, 0.025, 0.3, 180 / 365, false)
+    fxc = FXOption(100.0, 90.0, 0.05, 0.025, 0.3, 180 / 365, true)
     @test isapprox(evaluate(fxp, GarmanKohlhagen()), 3.51, atol=0.25)
     @test isapprox(evaluate(fxc, GarmanKohlhagen()), 14.48, atol=0.25)
 end
 
-ird = InterestRateDerivative(0.01875, 0.20, 0.01, 0.012, 180/365)
+ird = InterestRateDerivative(0.01875, 0.20, 0.01, 0.012, 180 / 365)
 
 @testset "Black-Karasinski" begin
     @test isapprox(evaluate(ird, BlackKarasinski(), 2), [0.2, 0.2, 0.2, 0.2], atol=0.25)


### PR DESCRIPTION
This MR: 

- Closes #12
- Add `isput` and `iscall` helpers. 
- Define parametric types, allowing same flexibility and avoiding perf penalty
- Adds a `JuliaFormatter.toml` file commonly used in Julia packages. 

I'm happy to change whatever is needed if some of these changes are not aligned with the package style. 